### PR TITLE
Make tests available on Linux.

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,6 @@
 import XCTest
-import SwiftBootstringTests
+import BootstringTests
 
 var tests = [XCTestCaseEntry]()
-tests += SwiftBootstringTests.allTests()
+tests += BootstringTests.allTests()
 XCTMain(tests)


### PR DESCRIPTION
The prefix "Swift" in Tests/LinuxMain.swift was omitted because the name of `.testTarget` in Package.swift doesn't have it.
